### PR TITLE
Additions

### DIFF
--- a/1password.sh
+++ b/1password.sh
@@ -36,10 +36,15 @@ from_op() {
     local OP_VARIABLES=()
     local OP_FILES=()
     local OVERWRITE_ENVVARS=1
+    local VERBOSE=0
     while [[ $# -gt 0 ]]; do
         case $1 in
         --no-overwrite)
             OVERWRITE_ENVVARS=0
+            shift
+            ;;
+        --verbose)
+            VERBOSE=1
             shift
             ;;
         --*)
@@ -84,6 +89,14 @@ from_op() {
             done
         )"
     fi
+
+    if [[ -z "$OP_INPUT" ]]; then
+        # There are no environment variables to load from op, no need to run op.
+        [[ "$VERBOSE" == "0" ]] || log_status "from_op: No variables to load from 1Password"
+        return 0
+    fi
+
+    [[ "$VERBOSE" == "0" ]] || log_status "from_op: Loading variables from 1Password"
 
     if ! has op; then
         log_error "1Password CLI 'op' not found"

--- a/1password.sh
+++ b/1password.sh
@@ -48,23 +48,11 @@ from_op() {
         return 1
         ;;
     esac
-
-    local var val
-    local -a op_sessions
-
-    # Store OP_SESSION_* variables, as `op run` removes them
-    for var in "${!OP_SESSION_@}"; do
-        eval "val=\$$var"
-        op_sessions+=("$var=$val")
-    done
-
-    direnv_load op run --env-file /dev/stdin --no-masking -- direnv dump < <(
+    local OP_INPUT
+    OP_INPUT="$(
         # Concatenate function args and stdin (if any)
         [[ $# == 0 ]] || printf '%s\n' "${@}"
         [[ -t 0 ]] || cat
-    )
-
-    for var in "${op_sessions[@]}"; do
-        export "${var?}"
-    done
+    )"
+    eval "$(direnv dotenv bash <(echo -n "$OP_INPUT" | op inject))"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
-# 0.1.0 / _Not released yet_
 
-* First release!
+# 0.1.0 / 2022-01-18
+
+- First release!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.0 / 2024-09-16
+
+- Drop support for 1password CLI v1.x.
+- Use `op inject` instead of `op run` to make Ctrl+C work.
+- Add option `--no-overwrite` to avoid overwriting already set environment variables.
+- Add option `--verbose` for more output while loading direnv.
 
 # 0.1.0 / 2022-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.0 / 2024-09-16
+# 1.0.0 / 2024-09-21
 
 - Drop support for 1password CLI v1.x.
 - Use `op inject` instead of `op run` to make Ctrl+C work.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example `.envrc`:
 
 ```bash
 # Download the latest version. See below for other installation methods.
-source_url "https://github.com/tmatilai/direnv-1password/raw/v0.2.0/1password.sh" \
+source_url "https://github.com/tmatilai/direnv-1password/raw/v1.0.0/1password.sh" \
     "sha256-EGpCcHQA5inHmMmkvj+TqIjPeNzzvG4F+BUXfFKb1c0="
 
 # Fetch one secret and export it into the specified environment variable

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 This repository includes a [direnv](https://direnv.net) library/extension for fetching secrets using [1Password CLI](https://support.1password.com/command-line/).
 
-It is easy enough to use the 1Password CLI (`op`) directly, but versions 1 and 2 are not compatible. This library includes helpers which work with both versions.
-
-_**NOTE:** 1Password CLI v2 is still in **Early Access** phase. Likewise this library is still finding the best way to work with it._
-_The configuration syntax might still change, and compatibility can't be promised._
-
 ---
 
 ## Usage
@@ -62,7 +57,7 @@ Future versions of the library hopefully offer helpers for the login, too.
 ## Requirements
 
 - [direnv](https://direnv.net). Might/should work with any somehow recent v2 version. Developed initially with v2.30.
-- [1Password CLI](https://support.1password.com/command-line/) (`op`). Developed with v1.2 and 2.0.0-beta.8.
+- [1Password CLI 2.x](https://support.1password.com/command-line/) (`op`).
 - A shell supported by direnv. Bash v3+ should work.
 
 ---

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Example `.envrc`:
 
 ```bash
 # Download the latest version. See below for other installation methods.
-source_url "https://github.com/tmatilai/direnv-1password/raw/v0.1.0/1password.sh" \
-    "sha256-EBpKlq0fYtsxTUCun/ppQIt10RUyhifGt+740l2CJlg="
+source_url "https://github.com/tmatilai/direnv-1password/raw/v0.2.0/1password.sh" \
+    "sha256-EGpCcHQA5inHmMmkvj+TqIjPeNzzvG4F+BUXfFKb1c0="
 
 # Fetch one secret and export it into the specified environment variable
 from_op MY_SECRET=op://vault/item/field

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ from_op <<OP
     FIRST_SECRET=op://vault/item/field
     OTHER_SECRET=op://...
 OP
+
+# Multiple secrets can be fetched from a file as well.
+# direnv will reload when the file changes.
+from_op .1password
+
+# Only load a secret from OP if it wasn't already set in `.env`.
+dotenv_if_exists
+from_op --no-overwrite MY_SECRET=op://vault/item/field
+
+# Show the status of 1password while loading direnv.
+from_op --verbose MY_SECRET=op://vault/item/field
 ```
 
 ### Secrets reference


### PR DESCRIPTION
I'm using `direnv-1password` more and more and there were some things I'd like to add. This PR are all of the additions/changes. If you'd like to have separate PRs or want to skip some of these commits, feel free to do so or ask :+1:

See the individual commit messages for more info.

It basically allows combining a `.env` file with 1password. All variables that were not loaded from `.env` will be loaded from 1password. If all variables were already loaded by `.env`, then 1password will not be called nor used. People who do not like to use 1password can still use `.env` this way.