### PR TITLE
allow special characters in passwords

### DIFF
--- a/1password.sh
+++ b/1password.sh
@@ -110,5 +110,5 @@ from_op() {
         ;;
     esac
 
-    eval "$(direnv dotenv bash <(echo "$OP_INPUT" | op inject))"
+    eval "$(direnv dotenv bash <(echo "$OP_INPUT" | op inject | while read -r line; do key="${line%%=*}"; value="${line#*=}"; echo "${key}=${value@Q}"; done))"
 }

--- a/1password.sh
+++ b/1password.sh
@@ -110,5 +110,15 @@ from_op() {
         ;;
     esac
 
-    eval "$(direnv dotenv bash <(echo "$OP_INPUT" | op inject | while read -r line; do key="${line%%=*}"; value="${line#*=}"; echo "${key}=${value@Q}"; done))"
+    eval "$(direnv dotenv bash <(
+        echo "$OP_INPUT" |
+        op inject |
+        # Convert KEY=VALUE to KEY='VALUE' to avoid direnv from substituting $ in values.
+        while read -r line
+        do
+            key="${line%%=*}"
+            value="${line#*=}"
+            echo "${key}=${value@Q}"
+        done
+    ))"
 }


### PR DESCRIPTION
Currently it is not possible to have `$`, `"` or `\` in passwords. Specifically, `$...` will be expanded.

`op inject` will always output raw `KEY=VALUE` without any escaping or quoting. `direnv dotenv` interprets `$` and will expand variables. `direnv dotenv` also supports `KEY='VALUE'` strings to avoid expansions.

So the implementation will use `${value@Q}`, which apparently outputs a single-quoted string of `value` with proper quoting and escaping of special characters.