### PR TITLE
Prepare to release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1 / 2025-03-16
+
+- Allow special characters in passwords, like `$`, `"` or `\`.
+
 # 1.0.0 / 2024-09-21
 
 - Drop support for 1password CLI v1.x.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Example `.envrc`:
 
 ```bash
 # Download the latest version. See below for other installation methods.
-source_url "https://github.com/tmatilai/direnv-1password/raw/v1.0.0/1password.sh" \
-    "sha256-EGpCcHQA5inHmMmkvj+TqIjPeNzzvG4F+BUXfFKb1c0="
+source_url "https://github.com/tmatilai/direnv-1password/raw/v1.0.1/1password.sh" \
+    "sha256-XVvkyYMk9gLzuuh5KCJi8VMTKRZcm/BrXPIMkjX4Eeg="
 
 # Fetch one secret and export it into the specified environment variable
 from_op MY_SECRET=op://vault/item/field


### PR DESCRIPTION
This includes the commit for `main` to prepare for v1.0.1. I tried to push both main and the v1.0.1 tag. The tag creation succeeded, but it isn't allowed to directly push to main, so I created this PR instead.

The source url found using:

```
$ direnv fetchurl https://github.com/tmatilai/direnv-1password/blob/main/1password.sh
Found hash: sha256-XVvkyYMk9gLzuuh5KCJi8VMTKRZcm/BrXPIMkjX4Eeg=
```