### PR TITLE
Add support for both "op://" and "op get item" secret references

### DIFF
--- a/1password.sh
+++ b/1password.sh
@@ -4,7 +4,7 @@
 # 1Password helpers for direnv configuration.
 #
 # VERSION:
-#    0.1.0
+#    0.1.1
 #
 # HOMEPAGE:
 #     https://github.com/tmatilai/direnv-1password

--- a/1password.sh
+++ b/1password.sh
@@ -30,7 +30,13 @@
 #        OTHER_SECRET=op://...
 #    OP
 #
+#    from_op <<OP
+#        USERNAME=op item get <item-id> --fields username
+#        PASSWORD=op read "op://vault/item/password"
+#    OP
+#
 # Reads environment variable values from 1Password.
+# Supports op:// references and direct op commands.
 #
 from_op() {
     local OP_VARIABLES=()
@@ -112,13 +118,39 @@ from_op() {
 
     eval "$(direnv dotenv bash <(
         echo "$OP_INPUT" |
-        op inject |
-        # Convert KEY=VALUE to KEY='VALUE' to avoid direnv from substituting $ in values.
-        while read -r line
-        do
-            key="${line%%=*}"
-            value="${line#*=}"
-            echo "${key}=${value@Q}"
+        while IFS= read -r line; do
+            # Skip empty lines and comments
+            [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+
+            # Extract variable name and value/command
+            if [[ "$line" =~ ^([^=]+)=(.+)$ ]]; then
+                key="${BASH_REMATCH[1]}"
+                value="${BASH_REMATCH[2]}"
+
+                # Check if it's a direct op command (starts with 'op ')
+                if [[ "$value" =~ ^op[[:space:]] ]]; then
+                    result=$(eval "$value" 2>&1)
+                    if [[ $? -eq 0 ]]; then
+                        echo "${key}=${result@Q}"
+                    else
+                        log_error "from_op: Failed to execute: $value" >&2
+                        log_error "from_op: Error: $result" >&2
+                        exit 1
+                    fi
+                else
+                    # Use op inject for op:// references
+                    injected=$(echo "$line" | op inject 2>&1)
+                    if [[ $? -eq 0 ]]; then
+                        # Extract the value after injection
+                        injected_value="${injected#*=}"
+                        echo "${key}=${injected_value@Q}"
+                    else
+                        log_error "from_op: Failed to inject: $line" >&2
+                        log_error "from_op: Error: $injected" >&2
+                        exit 1
+                    fi
+                fi
+            fi
         done
     ))"
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ from_op <<OP
     OTHER_SECRET=op://...
 OP
 
+# You can also use 'op item get' commands directly (without specifying a vault)
+from_op --verbose <<OP
+    MY_SECRET=op item get <item id> --format json --fields <field name> | jq -r .value
+OP
+
 # Multiple secrets can be fetched from a file as well.
 # direnv will reload when the file changes.
 from_op .1password
@@ -37,6 +42,8 @@ from_op --verbose MY_SECRET=op://vault/item/field
 ### Secrets reference
 
 The reference format is [described here](https://developer.1password.com/docs/cli/secrets-reference-syntax/). Vault, item and field can be referred either by name or ID.
+
+You can also use `op` commands directly (e.g., `op item get <item-id> --fields username`). This is useful for item IDs without specifying a vault, or for piping through tools like `jq`.
 
 With 1Password CLI v1 the section (referred in the docs) can not be used, so in some cases the item ID has to be used.
 


### PR DESCRIPTION
Hey, not sure if you are interested in merging this, but I've added support for referencing secrets also through "op item get <item id>". I usually prefer that as I don't have to specify the vault and can only reference it by the item id that can be copy / pasted from 1Password more easily.

Example with both ways:
```
from_op --verbose <<OP
    MY_SECRET=op item get <item id> --format json --fields username | jq -r .value
    MY_SECRET_2=op://Private/<item id>/username
OP
```

Let me know what you think! I've tested both ways and both work as expected.