### PR TITLE
Skip empty keys in key-value parsing

### DIFF
--- a/1password.sh
+++ b/1password.sh
@@ -118,6 +118,10 @@ from_op() {
         do
             key="${line%%=*}"
             value="${line#*=}"
+
+            # Sometimes $key can be empty
+            if [[ -z "$key" ]]; then continue; fi
+            
             echo "${key}=${value@Q}"
         done
     ))"


### PR DESCRIPTION
Added a check to skip empty keys in the key-value parsing loop.