### PR TITLE
Add GitHub Action masking

### DIFF
--- a/1password.sh
+++ b/1password.sh
@@ -26,6 +26,8 @@ from_op() {
     local OP_OPTIONS=()
     local OVERWRITE_ENVVARS=1
     local VERBOSE=0
+    local GHA_MASKING=1
+    [[ ${GITHUB_ACTIONS:-} == "true" ]] || GHA_MASKING=0
     local VALID_VAR_NAME_REGEX='[A-Za-z_][A-Za-z0-9_]*'
 
     if ! has op; then
@@ -48,6 +50,10 @@ from_op() {
                 ;;
             --verbose)
                 VERBOSE=1
+                shift
+                ;;
+            --no-gha-masking)
+                GHA_MASKING=0
                 shift
                 ;;
             --account)
@@ -128,6 +134,16 @@ from_op() {
     if ! injected="$(printf '%s\n' "$OP_INPUT" | op inject "${OP_OPTIONS[@]}")"; then
         log_error "from_op: 1Password injection failed"
         return 1
+    fi
+
+    if [[ $GHA_MASKING -ne 0 ]]; then
+        # Mask secret values in GitHub Actions logs.
+        # See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#using-workflow-commands-to-access-toolkit-functions
+        printf '%s\n' "$injected" \
+            | while read -r line; do
+                value="${line#*=}"
+                [[ -z $value ]] || echo "::add-mask::${value}"
+            done
     fi
 
     eval "$(direnv dotenv bash <(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Mask secret values in GitHub Actions logs by default (when `$GITHUB_ACTIONS=true`). Add option `--no-gha-masking` to disable it.
+
 # 1.1.0 / 2025-11-26
 
 - Add `--account` option to specify which 1Password account to use.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ from_op --no-overwrite MY_SECRET=op://vault/item/field
 # Use a specific 1Password account.
 # Also show the status of 1Password while loading direnv.
 from_op --account my.1password.com --verbose MY_SECRET=op://vault/item/field
+
+# When running in GitHub Actions (`GITHUB_ACTIONS=true`) secret values are
+# masked in the logs by default. Disable it with `--no-gha-masking`.
+from_op --no-gha-masking MY_SECRET=op://vault/item/field
 ```
 
 ### Secrets reference

--- a/tests/from_op.bats
+++ b/tests/from_op.bats
@@ -192,3 +192,33 @@ BASH
     [[ $output == *"MY_SECRET=single-secret"* ]]
     [ "$(<"$OP_ARGS_LOG")" = "--account my.1password.com" ]
 }
+
+@test "masks secret values when running in GitHub Actions" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export GITHUB_ACTIONS=true
+from_op MY_SECRET=op://vault/item/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "::add-mask::single-secret" ]
+    [ "${lines[1]}" = "MY_SECRET=single-secret" ]
+}
+
+@test "does not mask secret values in GitHub Actions with --no-gha-masking" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export GITHUB_ACTIONS=true
+from_op --no-gha-masking MY_SECRET=op://vault/item/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output != *"::add-mask::"* ]]
+    [ "$output" = "MY_SECRET=single-secret" ]
+}


### PR DESCRIPTION
I have based this on top of https://github.com/tmatilai/direnv-1password/pull/18, so that I had the ability to add tests.

Currently whenever direnv-1password is used inside GitHub Actions secrets can potentially be logged to github actions, exposing secrets. Just to be sure: direnv nor 1password are exposing the secrets, that could potentially happen in later GHA steps.

To avoid this, this PR detects whether it is running inside GitHub Actions and uses [`add-mask`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#masking-a-value-in-a-log) to mark the value as sensitive. GitHub Actions will then mask all text with that value in the logs.

This can also be explicitly disabled using `--no-gha-masking`.

I've added a changelog entry for a future version release.