### PR TITLE
Add tests and fix regression

### DIFF
--- a/1password.sh
+++ b/1password.sh
@@ -26,7 +26,7 @@ from_op() {
     local OP_OPTIONS=()
     local OVERWRITE_ENVVARS=1
     local VERBOSE=0
-    local VALID_VAR_NAME_REGEX='^[A-Za-z_][A-Za-z0-9_]*$'
+    local VALID_VAR_NAME_REGEX='[A-Za-z_][A-Za-z0-9_]*'
 
     if ! has op; then
         log_error "1Password CLI 'op' not found"
@@ -104,7 +104,7 @@ from_op() {
                 [[ -z $line || $line =~ ^[[:space:]]*# ]] && continue
 
                 # Validate variable name matches shell identifier rules
-                if [[ $line =~ ^($VALID_VAR_NAME_REGEX)= ]]; then
+                if [[ $line =~ ^[[:space:]]*($VALID_VAR_NAME_REGEX)[[:space:]]*= ]]; then
                     VARIABLE_NAME="${BASH_REMATCH[1]}"
                     # Respect --no-overwrite even if the variable is set to empty.
                     if [[ -z ${!VARIABLE_NAME+x} ]]; then
@@ -140,7 +140,7 @@ from_op() {
                 value="${line#*=}"
 
                 # Validate key is a valid shell identifier
-                if [[ ! $key =~ $VALID_VAR_NAME_REGEX ]]; then
+                if [[ ! $key =~ ^$VALID_VAR_NAME_REGEX$ ]]; then
                     log_error "from_op: Invalid variable name: $key"
                     continue
                 fi

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ SHELL = bash
 XDG_CONFIG_HOME ?= $(HOME)/.config
 
 SH_FILE = 1password.sh
+TEST_FILES = tests/*.bash tests/*.bats
+BATS ?= bats
 
 .PHONY: all
 all:
@@ -14,12 +16,13 @@ install:
 
 .PHONY: test
 test:
-	shellcheck $(SH_FILE)
-	shfmt -d -i 4 -s -ci -bn $(SH_FILE)
+	shellcheck $(SH_FILE) $(TEST_FILES)
+	shfmt -d -i 4 -s -ci -bn $(SH_FILE) $(TEST_FILES)
+	$(BATS) tests
 
 .PHONY: fmt
 fmt:
-	shfmt -w -i 4 -s -ci -bn $(SH_FILE)
+	shfmt -w -i 4 -s -ci -bn $(SH_FILE) $(TEST_FILES)
 
 # Print out the hash to be used in direnv configuration.
 .PHONY: hash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "1Password helpers for direnv";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs systems (system:
+          f (import nixpkgs { inherit system; }));
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            bats
+            shellcheck
+            shfmt
+          ];
+        };
+      });
+    };
+}

--- a/tests/from_op.bats
+++ b/tests/from_op.bats
@@ -84,6 +84,20 @@ BASH
     [ "${lines[1]}" = "OTHER_SECRET=other-secret" ]
 }
 
+@test "preserves dollar signs in secret values" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+from_op MY_SECRET=op://vault/dollar/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    expected=MY_SECRET=pa\$\$word\$with\$dollars
+    [ "$output" = "$expected" ]
+}
+
 @test "fetches multiple secrets from a file and watches it" {
     secrets_file="$BATS_TEST_TMPDIR/.1password"
     cat >"$secrets_file" <<'BASH'

--- a/tests/from_op.bats
+++ b/tests/from_op.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/.." && pwd)
+    export OP_ARGS_LOG="$BATS_TEST_TMPDIR/op-args.log"
+    export WATCH_FILE_LOG="$BATS_TEST_TMPDIR/watch-file.log"
+    : >"$OP_ARGS_LOG"
+    : >"$WATCH_FILE_LOG"
+}
+
+run_envrc() {
+    local envrc=$1
+
+    run bash -c '
+        set -euo pipefail
+        cd "$1"
+        source ./tests/stubs.bash
+        source ./1password.sh
+        source "$2"
+    ' bash "$REPO_ROOT" "$envrc"
+}
+
+@test "fetches one secret into the specified environment variable" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+from_op MY_SECRET=op://vault/item/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "MY_SECRET=single-secret" ]
+}
+
+@test "fetches multiple secrets from stdin" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+from_op <<OP
+FIRST_SECRET=op://vault/first/field
+OTHER_SECRET=op://vault/other/field
+OP
+printf 'FIRST_SECRET=%s\n' "$FIRST_SECRET"
+printf 'OTHER_SECRET=%s\n' "$OTHER_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "FIRST_SECRET=first-secret" ]
+    [ "${lines[1]}" = "OTHER_SECRET=other-secret" ]
+}
+
+@test "fetches secrets from a stdin heredoc" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+from_op <<stdin
+MY_SECRET=op://vault/item/field
+stdin
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "MY_SECRET=single-secret" ]
+}
+
+@test "fetches secrets from an indented stdin heredoc" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+from_op <<OP
+    FIRST_SECRET=op://vault/first/field
+    OTHER_SECRET=op://vault/other/field
+OP
+printf 'FIRST_SECRET=%s\n' "$FIRST_SECRET"
+printf 'OTHER_SECRET=%s\n' "$OTHER_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "FIRST_SECRET=first-secret" ]
+    [ "${lines[1]}" = "OTHER_SECRET=other-secret" ]
+}
+
+@test "fetches multiple secrets from a file and watches it" {
+    secrets_file="$BATS_TEST_TMPDIR/.1password"
+    cat >"$secrets_file" <<'BASH'
+FILE_SECRET=op://vault/file/field
+BASH
+
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<BASH
+from_op "$secrets_file"
+printf 'FILE_SECRET=%s\n' "\$FILE_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "FILE_SECRET=file-secret" ]
+    [ "$(<"$WATCH_FILE_LOG")" = "$secrets_file" ]
+}
+
+@test "does not overwrite an existing environment variable with --no-overwrite" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+MY_SECRET=from-dotenv
+dotenv_if_exists
+from_op --no-overwrite MY_SECRET=op://vault/item/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "MY_SECRET=from-dotenv" ]
+    [ ! -s "$OP_ARGS_LOG" ]
+}
+
+@test "loads an unset environment variable with --no-overwrite" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+dotenv_if_exists
+from_op --no-overwrite MY_SECRET=op://vault/item/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "MY_SECRET=single-secret" ]
+}
+
+@test "uses a specific 1Password account and logs status when verbose" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+from_op --account my.1password.com --verbose MY_SECRET=op://vault/item/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"STATUS: from_op: Loading variables from 1Password"* ]]
+    [[ $output == *"MY_SECRET=single-secret"* ]]
+    [ "$(<"$OP_ARGS_LOG")" = "--account my.1password.com" ]
+}

--- a/tests/from_op.bats
+++ b/tests/from_op.bats
@@ -133,6 +133,37 @@ BASH
     [ "$output" = "MY_SECRET=single-secret" ]
 }
 
+@test "loads an indented unset environment variable with --no-overwrite" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+dotenv_if_exists
+from_op --no-overwrite <<OP
+    MY_SECRET=op://vault/item/field
+OP
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "MY_SECRET=single-secret" ]
+}
+
+@test "loads a tab-indented unset environment variable with --no-overwrite" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    printf '%s\n' \
+        'dotenv_if_exists' \
+        'from_op --no-overwrite <<OP' \
+        $'\tMY_SECRET=op://vault/item/field' \
+        'OP' \
+        "printf 'MY_SECRET=%s\\n' \"\$MY_SECRET\"" >"$envrc"
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "MY_SECRET=single-secret" ]
+}
+
 @test "uses a specific 1Password account and logs status when verbose" {
     envrc="$BATS_TEST_TMPDIR/envrc"
     cat >"$envrc" <<'BASH'

--- a/tests/stubs.bash
+++ b/tests/stubs.bash
@@ -61,6 +61,9 @@ op() {
             op://vault/file/field)
                 value=file-secret
                 ;;
+            op://vault/dollar/field)
+                value=pa\$\$word\$with\$dollars
+                ;;
             *)
                 value="value-for-${reference}"
                 ;;

--- a/tests/stubs.bash
+++ b/tests/stubs.bash
@@ -1,0 +1,71 @@
+has() {
+    [[ $1 == op ]]
+}
+
+watch_file() {
+    printf '%s\n' "$1" >>"${WATCH_FILE_LOG:?}"
+}
+
+log_error() {
+    printf 'ERROR: %s\n' "$*" >&2
+}
+
+log_status() {
+    printf 'STATUS: %s\n' "$*" >&2
+}
+
+direnv() {
+    if [[ $1 == dotenv && $2 == bash ]]; then
+        cat "${3:-/dev/stdin}"
+        return 0
+    fi
+
+    printf 'unexpected direnv invocation: %s\n' "$*" >&2
+    return 1
+}
+
+dotenv_if_exists() {
+    :
+}
+
+op() {
+    if [[ $1 == --version ]]; then
+        printf '2.30.0\n'
+        return 0
+    fi
+
+    if [[ $1 != inject ]]; then
+        printf 'unexpected op invocation: %s\n' "$*" >&2
+        return 1
+    fi
+
+    shift
+    printf '%s\n' "$*" >>"${OP_ARGS_LOG:?}"
+
+    while IFS= read -r line; do
+        [[ -z $line || $line =~ ^[[:space:]]*# ]] && continue
+
+        key=${line%%=*}
+        reference=${line#*=}
+
+        case $reference in
+            op://vault/item/field)
+                value=single-secret
+                ;;
+            op://vault/first/field)
+                value=first-secret
+                ;;
+            op://vault/other/field)
+                value=other-secret
+                ;;
+            op://vault/file/field)
+                value=file-secret
+                ;;
+            *)
+                value="value-for-${reference}"
+                ;;
+        esac
+
+        printf '%s=%s\n' "$key" "$value"
+    done
+}


### PR DESCRIPTION
The latest release didn't work for some of my projects. They use indented HEREDOC, which failed. I introduced [BATS](https://bats-core.readthedocs.io/en/stable/) to run individual tests and introduced tests based on the README examples. This includes a test that failed because of the indentation. I fixed that regession in this PR as well.