### PR TITLE
fix dollar sign corruption in dotenv quoting

### DIFF
--- a/1password.sh
+++ b/1password.sh
@@ -145,8 +145,12 @@ from_op() {
                     continue
                 fi
 
-                # Quote the value
-                printf '%s=%q\n' "$key" "$value"
+                # Quote the value using POSIX single-quote form (${var@Q}).
+                # NOTE: do not use `printf %q` here: it emits bash
+                # backslash-escapes (e.g. pa\$\$word) which `direnv dotenv`
+                # (a godotenv parser, not bash) does not understand and
+                # mangles, corrupting values that contain `$`.
+                printf '%s=%s\n' "$key" "${value@Q}"
             done
     ))"
 }

--- a/tests/stubs.bash
+++ b/tests/stubs.bash
@@ -16,8 +16,12 @@ log_status() {
 
 direnv() {
     if [[ $1 == dotenv && $2 == bash ]]; then
-        cat "${3:-/dev/stdin}"
-        return 0
+        # Delegate to the real direnv binary so tests exercise its actual
+        # dotenv (godotenv) parser. Using `cat` here would bypass parsing and
+        # let bash's own `eval` interpret the output, hiding quoting bugs such
+        # as `printf %q` backslash-escapes that direnv does not understand.
+        command direnv dotenv bash "${3:-/dev/stdin}"
+        return
     fi
 
     printf 'unexpected direnv invocation: %s\n' "$*" >&2


### PR DESCRIPTION
This change is very similar to a previous change: https://github.com/tmatilai/direnv-1password/pull/4

Apparently the test did not correctly check for `$` in 1password values because direnv is being mocked as `cat` in the tests. Instead, we need it to use `direnv dotenv bash`, so that it'll use the right quotation/syntax for loading variables. When using this in the tests, the `$`-test fails.

To fix usage of `$` in 1password values, I have applied the same fix as in #4: `${value@Q}` instead of `%q`.

See also https://github.com/direnv/direnv/issues/1278