### PR TITLE
run tests in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Run tests
+        run: nix develop --command make test

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
         default = pkgs.mkShell {
           packages = with pkgs; [
             bats
+            direnv
             shellcheck
             shfmt
           ];


### PR DESCRIPTION
Currently the tests are not automatically run in CI. This PR enabled GitHub Actions using Nix flake to run `make test`.