### PR TITLE
unset GITHUB_ACTIONS for test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
             experimental-features = nix-command flakes
 
       - name: Run tests
-        run: nix develop --command make test
+        run: env --unset=GITHUB_ACTIONS nix develop --command make test


### PR DESCRIPTION
Currently the test-suite runs with `GITHUB_ACTIONS=true` in CI. That causes github masking output to happen inside the tests where it shouldn't.