### PR TITLE
feat: Add from_op_signin helper and from_op --signin option

### DIFF
--- a/1password.sh
+++ b/1password.sh
@@ -25,6 +25,7 @@ from_op() {
     local OP_FILES=()
     local OP_OPTIONS=()
     local OVERWRITE_ENVVARS=1
+    local SIGNIN=0
     local VERBOSE=0
     local GHA_MASKING=1
     [[ ${GITHUB_ACTIONS:-} == "true" ]] || GHA_MASKING=0
@@ -46,6 +47,10 @@ from_op() {
         case $1 in
             --no-overwrite)
                 OVERWRITE_ENVVARS=0
+                shift
+                ;;
+            --signin)
+                SIGNIN=1
                 shift
                 ;;
             --verbose)
@@ -127,6 +132,16 @@ from_op() {
         return 0
     fi
 
+    if [[ $SIGNIN -ne 0 ]]; then
+        # Opt-in only: without `--signin` none of this runs, and `from_op`
+        # behaves exactly as it did before the option existed. It is done here,
+        # after the short-circuit above, so that a load with nothing to fetch
+        # still spends no subprocess on 1Password.
+        local SIGNIN_OPTIONS=()
+        [[ $VERBOSE -eq 0 ]] || SIGNIN_OPTIONS+=(--verbose)
+        from_op_signin ${SIGNIN_OPTIONS[@]+"${SIGNIN_OPTIONS[@]}"} ${OP_OPTIONS[@]+"${OP_OPTIONS[@]}"} || return 1
+    fi
+
     [[ $VERBOSE -eq 0 ]] || log_status "from_op: Loading variables from 1Password"
 
     # Run op inject first to catch and report errors before eval.
@@ -169,4 +184,187 @@ from_op() {
                 printf '%s=%s\n' "$key" "${value@Q}"
             done
     ))"
+}
+
+# Ensure that a usable 1Password session exists.
+# Returns 0 when the session is usable, 1 when there is none and it could not be
+# established, and 2 when the 1Password CLI is not installed.
+from_op_signin() {
+    local OP_OPTIONS=()
+    local ACCOUNT=""
+    local ACCOUNT_SOURCE=""
+    local INTERACTIVE=1
+    local TIMEOUT=10
+    local VERBOSE=0
+    local QUIET=0
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --account)
+                if [[ $# -lt 2 ]]; then
+                    log_error "from_op_signin: --account requires an argument"
+                    return 1
+                fi
+                ACCOUNT="$2"
+                ACCOUNT_SOURCE="argument"
+                OP_OPTIONS+=(--account "$2")
+                shift 2
+                ;;
+            --no-interactive)
+                INTERACTIVE=0
+                shift
+                ;;
+            --timeout)
+                if [[ $# -lt 2 ]]; then
+                    log_error "from_op_signin: --timeout requires an argument"
+                    return 1
+                fi
+                if [[ ! $2 =~ ^[0-9]+$ ]] || [[ $2 -eq 0 ]]; then
+                    log_error "from_op_signin: --timeout requires a positive number of seconds: $2"
+                    return 1
+                fi
+                TIMEOUT="$2"
+                shift 2
+                ;;
+            --quiet)
+                QUIET=1
+                VERBOSE=0
+                shift
+                ;;
+            --verbose)
+                VERBOSE=1
+                QUIET=0
+                shift
+                ;;
+            --*)
+                log_error "from_op_signin: Unknown option: $1"
+                return 1
+                ;;
+            *)
+                log_error "from_op_signin: Unexpected argument: $1"
+                return 1
+                ;;
+        esac
+    done
+
+    if ! has op; then
+        log_error "1Password CLI 'op' not found"
+        return 2
+    fi
+
+    if [[ -z $ACCOUNT ]]; then
+        if [[ -n ${OP_ACCOUNT:-} ]]; then
+            ACCOUNT="$OP_ACCOUNT"
+            ACCOUNT_SOURCE="environment"
+        else
+            ACCOUNT="my.1password.com"
+            ACCOUNT_SOURCE="default"
+            OP_OPTIONS+=(--account "$ACCOUNT")
+        fi
+    fi
+
+    local STATUS=0
+    local OP_ERROR=""
+    OP_ERROR="$(_from_op_session_valid "$TIMEOUT" ${OP_OPTIONS[@]+"${OP_OPTIONS[@]}"})" || STATUS=$?
+
+    if [[ $STATUS -eq 0 ]]; then
+        [[ $VERBOSE -eq 0 ]] || log_status "from_op_signin: 1Password session is active"
+        return 0
+    fi
+
+    if [[ $STATUS -eq 124 ]]; then
+        # Nothing to add by trying to sign in: that would only wait again.
+        [[ $QUIET -ne 0 ]] || log_error "from_op_signin: 1Password did not answer in ${TIMEOUT}s"
+        return 1
+    fi
+
+    [[ $VERBOSE -eq 0 || -z $OP_ERROR ]] || log_status "from_op_signin: $OP_ERROR"
+
+    if [[ $INTERACTIVE -ne 0 ]]; then
+        [[ $VERBOSE -eq 0 ]] || log_status "from_op_signin: Signing in to 1Password"
+
+        # One attempt only, never a retry loop, and always time-boxed. As `op`
+        # gets no terminal to prompt on, this can only succeed through the
+        # 1Password desktop app integration, which answers without one.
+        local SIGNIN_OUTPUT=""
+        local SIGNIN_ERROR_FILE=""
+        STATUS=0
+        if [[ $QUIET -eq 0 ]]; then
+            SIGNIN_ERROR_FILE="$(mktemp "${TMPDIR:-/tmp}/from_op_signin.XXXXXX")" || return 1
+            SIGNIN_OUTPUT="$(_from_op_run_timeout "$TIMEOUT" op signin ${OP_OPTIONS[@]+"${OP_OPTIONS[@]}"} 2>"$SIGNIN_ERROR_FILE")" || STATUS=$?
+            rm -f "$SIGNIN_ERROR_FILE"
+        else
+            SIGNIN_OUTPUT="$(_from_op_run_timeout "$TIMEOUT" op signin ${OP_OPTIONS[@]+"${OP_OPTIONS[@]}"} 2>/dev/null)" || STATUS=$?
+        fi
+
+        if [[ $STATUS -eq 124 ]]; then
+            [[ $QUIET -ne 0 ]] || log_error "from_op_signin: 1Password did not answer in ${TIMEOUT}s"
+            return 1
+        fi
+
+        if [[ $STATUS -eq 0 ]]; then
+            eval "$SIGNIN_OUTPUT"
+            if OP_ERROR="$(_from_op_session_valid "$TIMEOUT" ${OP_OPTIONS[@]+"${OP_OPTIONS[@]}"})"; then
+                [[ $VERBOSE -eq 0 ]] || log_status "from_op_signin: Signed in to 1Password"
+                return 0
+            fi
+        fi
+    fi
+
+    if [[ $QUIET -eq 0 ]]; then
+        if [[ $ACCOUNT_SOURCE == "environment" ]]; then
+            log_error "from_op_signin: No active 1Password session for OP_ACCOUNT ($ACCOUNT). Run 'op signin' with the same account and then 'direnv reload', or pass --account ACCOUNT."
+        else
+            log_error "from_op_signin: No active 1Password session for $ACCOUNT. Run: eval \"\$(op signin --account $ACCOUNT)\" and then 'direnv reload'"
+        fi
+    fi
+    return 1
+}
+
+# Run a command with a timeout, so that `.envrc` evaluation can never hang on
+# 1Password. The input is always /dev/null: `op` must not stall on a prompt that
+# direnv, which evaluates `.envrc` without a terminal on stdin, can never answer.
+# `timeout` is GNU coreutils, `gtimeout` its Homebrew name on macOS. When neither
+# is installed the command runs unwrapped, as the timeout is a safety net rather
+# than a requirement.
+_from_op_run_timeout() {
+    local TIMEOUT=$1
+    shift
+
+    local TIMEOUT_CMD=""
+    if command -v timeout >/dev/null 2>&1; then
+        TIMEOUT_CMD="timeout"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        TIMEOUT_CMD="gtimeout"
+    fi
+
+    local STATUS=0
+    if [[ -n $TIMEOUT_CMD ]]; then
+        # Status 124 means the command was killed on expiry. It is passed on as
+        # is: the caller reports it, because the error output of the command
+        # itself is captured and a timeout has to be told apart from a plain
+        # failure. Without a timeout command 124 can only come from `op` itself,
+        # which does not use it.
+        "$TIMEOUT_CMD" "$TIMEOUT" "$@" </dev/null || STATUS=$?
+    else
+        "$@" </dev/null || STATUS=$?
+    fi
+
+    return $STATUS
+}
+
+# Check whether `op` has a usable session, without prompting.
+# A service account token or a Connect host+token authenticate every `op`
+# invocation on their own, so there is no session to probe and no reason to spend
+# a subprocess on one. Otherwise `op whoami` is the probe: it exits non-zero when
+# signed out, and `--format=json` keeps that exit contract stable.
+# Error output of `op` is written to stdout for the caller to log if it wants to.
+_from_op_session_valid() {
+    local TIMEOUT=$1
+    shift
+
+    [[ -z ${OP_SERVICE_ACCOUNT_TOKEN:-} ]] || return 0
+    [[ -z ${OP_CONNECT_HOST:-} || -z ${OP_CONNECT_TOKEN:-} ]] || return 0
+
+    { _from_op_run_timeout "$TIMEOUT" op whoami --format=json "$@" >/dev/null; } 2>&1
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - Mask secret values in GitHub Actions logs by default (when `$GITHUB_ACTIONS=true`). Add option `--no-gha-masking` to disable it.
+- Add `from_op_signin` helper to check for and optionally establish a 1Password session.
+- Add option `--signin` to `from_op` to ensure a session before fetching secrets. Off by default.
 
 # 1.1.0 / 2025-11-26
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ from_op --no-overwrite MY_SECRET=op://vault/item/field
 # Also show the status of 1Password while loading direnv.
 from_op --account my.1password.com --verbose MY_SECRET=op://vault/item/field
 
+# Make sure that a 1Password session exists before fetching the secrets.
+# If no account is configured, this checks/signs in to my.1password.com.
+# Without `--signin` the session is never checked. See "1Password login" below.
+from_op --signin MY_SECRET=op://vault/item/field
+
+# Check the session separately, without ever prompting.
+from_op_signin --no-interactive || return
+
 # When running in GitHub Actions (`GITHUB_ACTIONS=true`) secret values are
 # masked in the logs by default. Disable it with `--no-gha-masking`.
 from_op --no-gha-masking MY_SECRET=op://vault/item/field
@@ -61,12 +69,52 @@ eval $(op signin ACCOUNT)
 eval (op signin ACCOUNT)
 ```
 
-The `.envrc` evaluation can then be forced with e.g. `direnv reload`.
+The `.envrc` evaluation can then be forced with e.g. `direnv reload`. This is still the recommended flow.
 
-Other option is to add the `op signin` command into the `.envrc`, but that will block the evaluation.
-This might go against the best practices with direnv, as `.envrc` evaluations should in general be fast and non-blocking. But you decide.
+#### Session helpers
 
-Future versions of the library hopefully offer helpers for the login, too.
+The session is never checked unless you ask for it. Plain `from_op` runs no extra commands, and behaves exactly like it does without any of the options below.
+
+Adding `--signin` verifies that a usable session exists before any secret is fetched, and tries to establish one if it does not. You then get an actionable error instead of a generic injection failure:
+
+```bash
+from_op --signin MY_SECRET=op://vault/item/field
+```
+
+If you do not pass `--account` and `OP_ACCOUNT` is not set, the helper checks and signs in with `--account my.1password.com`. This avoids the interactive 1Password account picker that `op signin` can show when multiple accounts are available. Use `--account ACCOUNT` or set `OP_ACCOUNT` when you want a different account:
+
+```bash
+from_op --signin --account team.1password.com MY_SECRET=op://vault/item/field
+```
+
+The same check is available on its own as the `from_op_signin` command. For example, to check the session without ever prompting, and to stop the evaluation if there is none:
+
+```bash
+from_op_signin --no-interactive || return
+```
+
+It accepts the following options:
+
+- `--account ACCOUNT` - use a specific 1Password account.
+- `--no-interactive` - only check for a session, never try to establish one.
+- `--timeout SECONDS` - how long 1Password is waited for. Defaults to 10.
+- `--quiet` / `--verbose` - suppress or expand the output. By default the command is silent unless it fails.
+
+And returns:
+
+- `0` when the session is usable,
+- `1` when there is none and it could not be established,
+- `2` when the 1Password CLI is not installed.
+
+The command is not hostile to `set -e`, so `from_op_signin || true` works if you want to ignore the result.
+
+#### Blocking behaviour
+
+Signing in can block, as it waits for the request to be approved in the 1Password app, and that is exactly why it is opt-in: `.envrc` evaluations should in general be fast and non-blocking.
+
+Note that direnv evaluates `.envrc` without a terminal. `op` is therefore always run without one, and can not ask for a password or an account selection: only the 1Password app integration, including the biometric unlock, can answer without terminal input. Signing in with a password stays a manual step, as described above. Use `from_op_signin --no-interactive` when you want a check that never tries to sign in at all. Either way the wait is bounded by `--timeout`.
+
+When `OP_SERVICE_ACCOUNT_TOKEN`, or both `OP_CONNECT_HOST` and `OP_CONNECT_TOKEN`, are set, `op` authenticates on every invocation and there is no session to check. The check is then skipped altogether, which keeps CI environments fast.
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
         default = pkgs.mkShell {
           packages = with pkgs; [
             bats
+            coreutils
             direnv
             shellcheck
             shfmt

--- a/tests/from_op.bats
+++ b/tests/from_op.bats
@@ -3,9 +3,16 @@
 setup() {
     REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/.." && pwd)
     export OP_ARGS_LOG="$BATS_TEST_TMPDIR/op-args.log"
+    export OP_WHOAMI_LOG="$BATS_TEST_TMPDIR/op-whoami.log"
+    export OP_SIGNIN_LOG="$BATS_TEST_TMPDIR/op-signin.log"
+    export OP_SESSION_SENTINEL="$BATS_TEST_TMPDIR/op-session"
+    export OP_STUB_BIN="$BATS_TEST_TMPDIR/bin"
     export WATCH_FILE_LOG="$BATS_TEST_TMPDIR/watch-file.log"
     : >"$OP_ARGS_LOG"
+    : >"$OP_WHOAMI_LOG"
+    : >"$OP_SIGNIN_LOG"
     : >"$WATCH_FILE_LOG"
+    rm -f "$OP_SESSION_SENTINEL"
 }
 
 run_envrc() {
@@ -191,6 +198,91 @@ BASH
     [[ $output == *"STATUS: from_op: Loading variables from 1Password"* ]]
     [[ $output == *"MY_SECRET=single-secret"* ]]
     [ "$(<"$OP_ARGS_LOG")" = "--account my.1password.com" ]
+}
+
+@test "does not check the 1Password session without --signin" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+from_op MY_SECRET=op://vault/item/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "MY_SECRET=single-secret" ]
+    [ ! -s "$OP_WHOAMI_LOG" ]
+    [ ! -s "$OP_SIGNIN_LOG" ]
+}
+
+@test "signs in before fetching secrets with --signin" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+from_op --signin MY_SECRET=op://vault/item/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "MY_SECRET=single-secret" ]
+    [[ $(<"$OP_WHOAMI_LOG") == *"--account my.1password.com"* ]]
+    [[ $(<"$OP_SIGNIN_LOG") == *"--account my.1password.com"* ]]
+    [ "$(wc -l <"$OP_SIGNIN_LOG")" -eq 1 ]
+    [ -z "$(<"$OP_ARGS_LOG")" ]
+}
+
+@test "does not fetch secrets when --signin fails" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+export OP_STUB_SIGNIN_SUCCEEDS=0
+rc=0
+from_op --signin MY_SECRET=op://vault/item/field || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"exit=1"* ]]
+    [[ $output == *"ERROR: from_op_signin: No active 1Password session"* ]]
+    [[ $output != *"1Password injection failed"* ]]
+    [ ! -s "$OP_ARGS_LOG" ]
+}
+
+@test "passes the account to both the session check and the injection with --signin" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+from_op --signin --account my.1password.com MY_SECRET=op://vault/item/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "MY_SECRET=single-secret" ]
+    [[ $(<"$OP_WHOAMI_LOG") == *"--account my.1password.com"* ]]
+    [ "$(<"$OP_ARGS_LOG")" = "--account my.1password.com" ]
+}
+
+@test "does not check the session when there is nothing to load with --signin" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+MY_SECRET=from-dotenv
+dotenv_if_exists
+from_op --signin --no-overwrite MY_SECRET=op://vault/item/field
+printf 'MY_SECRET=%s\n' "$MY_SECRET"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "MY_SECRET=from-dotenv" ]
+    [ ! -s "$OP_WHOAMI_LOG" ]
+    [ ! -s "$OP_ARGS_LOG" ]
 }
 
 @test "masks secret values when running in GitHub Actions" {

--- a/tests/from_op_signin.bats
+++ b/tests/from_op_signin.bats
@@ -1,0 +1,333 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/.." && pwd)
+    export OP_ARGS_LOG="$BATS_TEST_TMPDIR/op-args.log"
+    export OP_WHOAMI_LOG="$BATS_TEST_TMPDIR/op-whoami.log"
+    export OP_SIGNIN_LOG="$BATS_TEST_TMPDIR/op-signin.log"
+    export OP_SESSION_SENTINEL="$BATS_TEST_TMPDIR/op-session"
+    export OP_STUB_BIN="$BATS_TEST_TMPDIR/bin"
+    export WATCH_FILE_LOG="$BATS_TEST_TMPDIR/watch-file.log"
+    : >"$OP_ARGS_LOG"
+    : >"$OP_WHOAMI_LOG"
+    : >"$OP_SIGNIN_LOG"
+    : >"$WATCH_FILE_LOG"
+    rm -f "$OP_SESSION_SENTINEL"
+}
+
+run_envrc() {
+    local envrc=$1
+
+    run bash -c '
+        set -euo pipefail
+        cd "$1"
+        source ./tests/stubs.bash
+        source ./1password.sh
+        source "$2"
+    ' bash "$REPO_ROOT" "$envrc"
+}
+
+@test "succeeds silently when a session is already active" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+from_op_signin
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ -s "$OP_WHOAMI_LOG" ]
+    [ ! -s "$OP_SIGNIN_LOG" ]
+}
+
+@test "reports how to sign in with --no-interactive" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+rc=0
+from_op_signin --no-interactive || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"exit=1"* ]]
+    [[ $output == *'ERROR: from_op_signin: No active 1Password session for my.1password.com.'* ]]
+    # shellcheck disable=SC2016 # the hint is a literal, not an expansion
+    [[ $output == *'eval "$(op signin --account my.1password.com)"'* ]]
+    [[ $(<"$OP_WHOAMI_LOG") == *"--account my.1password.com"* ]]
+    [ ! -s "$OP_SIGNIN_LOG" ]
+}
+
+@test "signs in when there is no session" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+from_op_signin
+printf 'OP_SESSION_test=%s\n' "$OP_SESSION_test"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "OP_SESSION_test=stub-token" ]
+    [ "$(wc -l <"$OP_SIGNIN_LOG")" -eq 1 ]
+    [[ $(<"$OP_SIGNIN_LOG") == *"--account my.1password.com"* ]]
+}
+
+@test "does not retry when the sign-in fails" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+export OP_STUB_SIGNIN_SUCCEEDS=0
+rc=0
+from_op_signin || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"exit=1"* ]]
+    [[ $output == *"ERROR: from_op_signin: No active 1Password session"* ]]
+    [[ $output != *"authorization prompt dismissed"* ]]
+    [ "$(wc -l <"$OP_SIGNIN_LOG")" -eq 1 ]
+}
+
+@test "uses a specific 1Password account" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+from_op_signin --account my.1password.com
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $(<"$OP_WHOAMI_LOG") == *"--account my.1password.com"* ]]
+    [[ $(<"$OP_SIGNIN_LOG") == *"--account my.1password.com"* ]]
+}
+
+@test "names the account in the sign-in hint when one is given" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+from_op_signin --no-interactive --account my.1password.com || true
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    # shellcheck disable=SC2016 # the hint is a literal, not an expansion
+    [[ $output == *'eval "$(op signin --account my.1password.com)"'* ]]
+}
+
+@test "uses OP_ACCOUNT instead of the fallback account" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+export OP_STUB_SIGNIN_SUCCEEDS=0
+export OP_ACCOUNT=team.1password.com
+rc=0
+from_op_signin || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"exit=1"* ]]
+    [[ $output == *"ERROR: from_op_signin: No active 1Password session for OP_ACCOUNT (team.1password.com)."* ]]
+    [[ $output == *"pass --account ACCOUNT"* ]]
+    [[ $(<"$OP_WHOAMI_LOG") != *"--account my.1password.com"* ]]
+    [[ $(<"$OP_SIGNIN_LOG") != *"--account my.1password.com"* ]]
+    [ "$(<"$OP_WHOAMI_LOG")" = "--format=json" ]
+    [ -z "$(<"$OP_SIGNIN_LOG")" ]
+}
+
+@test "logs the session status and the error of op when verbose" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+from_op_signin --verbose
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"STATUS: from_op_signin: [ERROR] you are not currently signed in"* ]]
+    [[ $output == *"STATUS: from_op_signin: Signing in to 1Password"* ]]
+    [[ $output == *"STATUS: from_op_signin: Signed in to 1Password"* ]]
+}
+
+@test "stays silent about a failure with --quiet" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+export OP_STUB_SIGNIN_SUCCEEDS=0
+rc=0
+from_op_signin --quiet || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "exit=1" ]
+}
+
+@test "accepts a timeout" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+from_op_signin --timeout 5
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ -s "$OP_WHOAMI_LOG" ]
+}
+
+@test "gives up when 1Password does not answer within the timeout" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_WHOAMI_DELAY=10
+rc=0
+from_op_signin --no-interactive --timeout 1 || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"exit=1"* ]]
+    [[ $output == *"from_op_signin: 1Password did not answer in 1s"* ]]
+}
+
+@test "rejects an invalid timeout" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+rc=0
+from_op_signin --timeout soon || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"exit=1"* ]]
+    [[ $output == *"ERROR: from_op_signin: --timeout requires a positive number of seconds: soon"* ]]
+    [ ! -s "$OP_WHOAMI_LOG" ]
+}
+
+@test "checks the session without timeout(1) available" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+PATH=""
+rc=0
+from_op_signin --no-interactive || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"exit=1"* ]]
+    [ -s "$OP_WHOAMI_LOG" ]
+}
+
+@test "skips the session check when a service account token is set" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+export OP_SERVICE_ACCOUNT_TOKEN=ops_token
+from_op_signin
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ ! -s "$OP_WHOAMI_LOG" ]
+    [ ! -s "$OP_SIGNIN_LOG" ]
+}
+
+@test "skips the session check when 1Password Connect is configured" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_STUB_SIGNED_IN=0
+export OP_CONNECT_HOST=http://localhost:8080
+export OP_CONNECT_TOKEN=connect_token
+from_op_signin
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ ! -s "$OP_WHOAMI_LOG" ]
+}
+
+@test "checks the session when only the Connect host is set" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+export OP_CONNECT_HOST=http://localhost:8080
+from_op_signin
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [ -s "$OP_WHOAMI_LOG" ]
+}
+
+@test "fails when the 1Password CLI is not installed" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+has() { return 1; }
+rc=0
+from_op_signin || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"exit=2"* ]]
+    [[ $output == *"ERROR: 1Password CLI 'op' not found"* ]]
+    [ ! -s "$OP_WHOAMI_LOG" ]
+}
+
+@test "fails on an unknown option" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+rc=0
+from_op_signin --nope || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"exit=1"* ]]
+    [[ $output == *"ERROR: from_op_signin: Unknown option: --nope"* ]]
+    [ ! -s "$OP_WHOAMI_LOG" ]
+}
+
+@test "fails on an unexpected argument" {
+    envrc="$BATS_TEST_TMPDIR/envrc"
+    cat >"$envrc" <<'BASH'
+rc=0
+from_op_signin my.1password.com || rc=$?
+printf 'exit=%s\n' "$rc"
+BASH
+
+    run_envrc "$envrc"
+
+    [ "$status" -eq 0 ]
+    [[ $output == *"exit=1"* ]]
+    [[ $output == *"ERROR: from_op_signin: Unexpected argument: my.1password.com"* ]]
+}

--- a/tests/stubs.bash
+++ b/tests/stubs.bash
@@ -38,6 +38,38 @@ op() {
         return 0
     fi
 
+    if [[ $1 == whoami ]]; then
+        shift
+        printf '%s\n' "$*" >>"${OP_WHOAMI_LOG:?}"
+
+        # Only used by the timeout tests, and only when set to a non-zero value.
+        [[ ${OP_STUB_WHOAMI_DELAY:-0} == 0 ]] || sleep "$OP_STUB_WHOAMI_DELAY"
+
+        # The sign-in branch below records a successful sign-in in a file, as it
+        # can not export anything back into the shell that called it.
+        if [[ ${OP_STUB_SIGNED_IN:-1} == 1 || -f ${OP_SESSION_SENTINEL:?} ]]; then
+            printf '{"url":"my.1password.com","user_uuid":"stub","account_uuid":"stub"}\n'
+            return 0
+        fi
+
+        printf "[ERROR] you are not currently signed in. Please run 'op signin --help' for instructions\n" >&2
+        return 1
+    fi
+
+    if [[ $1 == signin ]]; then
+        shift
+        printf '%s\n' "$*" >>"${OP_SIGNIN_LOG:?}"
+
+        if [[ ${OP_STUB_SIGNIN_SUCCEEDS:-1} != 1 ]]; then
+            printf '[ERROR] authorization prompt dismissed, please try again\n' >&2
+            return 1
+        fi
+
+        : >"${OP_SESSION_SENTINEL:?}"
+        printf 'export OP_SESSION_test="stub-token"\n'
+        return 0
+    fi
+
     if [[ $1 != inject ]]; then
         printf 'unexpected op invocation: %s\n' "$*" >&2
         return 1
@@ -76,3 +108,28 @@ op() {
         printf '%s=%s\n' "$key" "$value"
     done
 }
+
+# `timeout` execs its command and therefore can not see shell functions, so the
+# `op` stub has to exist as a real executable as well. The shim re-enters this
+# file and calls the function above, so that direct calls and `timeout op ...`
+# share one stub. Putting it first on PATH also shadows any real `op` installed
+# on the machine, which the test suite must never invoke.
+_stubs_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+if [[ ! -x ${OP_STUB_BIN:?}/op ]]; then
+    mkdir -p "$OP_STUB_BIN"
+    {
+        printf '%s\n' '#!/usr/bin/env bash'
+        printf 'source %q\n' "$_stubs_file"
+        printf '%s\n' 'op "$@"'
+    } >"$OP_STUB_BIN/op"
+    chmod +x "$OP_STUB_BIN/op"
+fi
+unset _stubs_file
+
+case ":$PATH:" in
+    *":$OP_STUB_BIN:"*) ;;
+    *)
+        PATH="$OP_STUB_BIN:$PATH"
+        export PATH
+        ;;
+esac


### PR DESCRIPTION
[feat: Add from_op_signin helper and from_op --signin option](https://github.com/tmatilai/direnv-1password/pull/23/commits/293d98d85d1cefa6c023dd7691a6cbec68c0422f)

- from_op requires a valid 1Password session otherwise only returns a generic error
- op inject provides no useful feedback when the session is missing
- added from_op_signin to check for a usable session and optionally establish one unless no interactive flag is set
- from_op_signin returns 0 when session is valid 1 when missing and 2 when op is not installed enabling envrc branching
- session check is opt in and only runs when signin flag is provided and after confirming there is data to fetch
- without the signin option from_op behavior remains unchanged and runs no extra commands
- all operations are time boxed using timeout gtimeout or fallback if neither is available
- op is always executed with stdin redirected to dev null to prevent blocking in non interactive envrc execution
- session check is skipped when using a service account token or connect host and token since each op call authenticates independently
- extended test stub for op to include whoami and signin commands
- installed stub as a real executable in path because timeout cannot invoke shell functions and to avoid calling a real op binary
- ensured test environment does not accidentally use a real op installation
- pinned coreutils in dev shell to provide consistent timeout behavior across macOS and Linux CI
- added separate coverage for environments without timeout installed
- verified that default from_op does not perform session checks and fails tests if this behavior changes
- updated documentation to replace earlier notes about future login helpers with the new session helper implementation
- Default signin checks to `my.1password.com` when no account is set
- Honor OP_ACCOUNT and explicit account before using the fallback
- Capture op signin stderr so prompt text does not corrupt direnv output
- Update docs and tests for account resolution behavior

Closes Issue https://github.com/tmatilai/direnv-1password/issues/22